### PR TITLE
Correct `menu expand` button behavior on toggle, and visual style to match Vocabulary

### DIFF
--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -552,13 +552,10 @@ body > footer .license svg {
         right: 0;
         display: inline-block;
         padding: .3em .5em;
-        border: 1px solid rgba(1,1,1,.1);
         border: none;
-        background: #F5F5F5;
-
-
         border-radius: 5px;
-
+        background: #F5F5F5;
+        
         text-transform: uppercase;
         font-family: 'Roboto Condensed';
         font-style: normal;
@@ -582,7 +579,6 @@ body > footer .license svg {
         margin: 0;
         padding: 0;
         margin-top: 1.5em;
-        /* background: #F5F5F5; */
     }
 
     .primary-menu.expand ul li {

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -543,17 +543,52 @@ body > footer .license svg {
 
     .masthead {
         padding-top: 60px;
+        display: block;
     }
+
+    button.expand-menu {
+        position: absolute;
+        top: 4em;
+        right: 0;
+        display: inline-block;
+        padding: .3em .5em;
+        border: 1px solid rgba(1,1,1,.1);
+        border: none;
+        background: #F5F5F5;
+        border-radius: 3px;
+        font-family: 'Source Sans Pro';
+        font-style: normal;
+        font-weight: 400; 
+        font-size: 1em;
+    }
+
     .primary-menu {
         display: none;
     }
+
+    .primary-menu.expand {
+        display: initial;
+    }
+
+    .primary-menu.expand ul {
+        display: block;
+        width: 100%;
+        margin: 0;
+        padding: 0;
+        margin-top: 1.5em;
+    }
+
+    .primary-menu.expand ul li {
+        margin: 0;
+        padding: 1em 0;
+        border-top: 1px solid rgba(1,1,1,.1);
+    }
+
     .ancilliary-menu {
         /* display: none; */
     }
 
-    button.expand-menu {
-        display: inline-block;
-    }
+
 
 }
 

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -555,7 +555,6 @@ body > footer .license svg {
         border: none;
         border-radius: 5px;
         background: #F5F5F5;
-        
         text-transform: uppercase;
         font-family: 'Roboto Condensed';
         font-style: normal;

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -548,22 +548,28 @@ body > footer .license svg {
 
     button.expand-menu {
         position: absolute;
-        top: 4em;
+        top: 4.5em;
         right: 0;
         display: inline-block;
         padding: .3em .5em;
         border: 1px solid rgba(1,1,1,.1);
         border: none;
         background: #F5F5F5;
-        border-radius: 3px;
-        font-family: 'Source Sans Pro';
+
+
+        border-radius: 5px;
+
+        text-transform: uppercase;
+        font-family: 'Roboto Condensed';
         font-style: normal;
-        font-weight: 400; 
+        font-weight: 700; 
         font-size: 1em;
+        padding: .5rem 1rem;
     }
 
     .primary-menu {
         display: none;
+        
     }
 
     .primary-menu.expand {
@@ -576,6 +582,7 @@ body > footer .license svg {
         margin: 0;
         padding: 0;
         margin-top: 1.5em;
+        /* background: #F5F5F5; */
     }
 
     .primary-menu.expand ul li {

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
 <header>
     <div class="masthead">
         <h1><a class="identity-logo" href="#">Creative Commons</a></h1>
-        <button class="expand-menu">expand menu</button>
+        <button class="expand-menu">Menu</button>
         <nav class="primary-menu">
             <ul>
                 <li><a href="">Who We Are</a></li>

--- a/src/js/vocabulary.js
+++ b/src/js/vocabulary.js
@@ -7,3 +7,12 @@ exploreButton.addEventListener('click', (event) => {
     explorePanel.classList.toggle('expand');
     // explorePanel.classList.toggle('hide');
 });
+
+
+const menuButton = document.querySelector('button.expand-menu');
+const menuPanel = document.querySelector('.primary-menu');
+
+menuButton.addEventListener('click', (event) => {
+    menuPanel.classList.toggle('expand');
+    // explorePanel.classList.toggle('hide');
+});


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes: 
* #9 

## Description
* Adds JavaScript click event to toggle expanded state of `primary navigation` on smaller devices
* Adds appropriate Vocabulary adjacent visual styles to `expand menu` button element.
* Changes the text to read from `expand menu` to `Menu`. 


## Tests
Tested via Docker.

## Screenshots

### Before

<img width="494" alt="Screen Shot 2023-04-18 at 3 45 51 PM" src="https://user-images.githubusercontent.com/109087089/232901275-d073186c-067d-4e6f-94c3-4595fb164786.png">



### After 
<img width="495" alt="Screen Shot 2023-04-18 at 3 46 25 PM" src="https://user-images.githubusercontent.com/109087089/232901340-55d5bf1f-e53b-469b-8dfb-122279e80466.png">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
