### PR TITLE
Implement appropriate styling in newsletter form, fill in URLs for footer navigation, and more general universal nav areas (social, license, etc.)

### DIFF
--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -90,11 +90,11 @@ header {
     border: 2px solid purple;
 }
 
-.masthead .primary-menu {
-    /* margin-top: 45px; */
-    /* vertical-align: bottom; */
+/* .masthead .primary-menu {
+    margin-top: 45px;
+    vertical-align: bottom;
     
-}
+} */
 
 .masthead .primary-menu ul {
     display: flex;
@@ -348,7 +348,7 @@ body > footer p a {
     /* better hyperlink underline typesetting inspired by Tufte CSS */
     --underline-color: var(--vocabulary-brand-color-turquoise);
     --underline-background-color: black;
-    color: 
+    color: var(--vocabulary-brand-color-turquoise);
     text-decoration: none;
 
     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
@@ -440,76 +440,55 @@ body > footer .subscribe {
 
 body > footer .subscribe form {
     display: flex;
+    justify-content: space-around;
+    width: 100%;
 }
 
 body > footer .subscribe form input {
-
-    -webkit-appearance: none;
-    align-items: center;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    box-shadow: none;
     display: inline-flex;
-    font-size: 1rem;
-    height: 2.5em;
-    justify-content: flex-start;
-    line-height: 1.5;
-    padding-bottom: calc(0.5em - 1px);
-    padding-left: calc(0.75em - 1px);
-    padding-right: calc(0.75em - 1px);
-    padding-top: calc(0.5em - 1px);
     position: relative;
+    justify-content: flex-start;
+    align-items: center;
     vertical-align: top;
-
+    box-sizing: border-box;
+    
+    -webkit-appearance: none;
+    background-color: transparent;
+    color: rgb(118, 118, 118);
     font-family: "Source Sans Pro", sans-serif;
+    font-size: 1em;
     font-weight: 600;
     line-height: 1.3;
-    border-width: 0.125rem;
-    box-sizing: border-box;
-    height: 2.5em;
-    padding-left: 0.5rem;
+    border: 2px solid rgb(118, 118, 118);;
+    /* border-radius: 4px; */
     box-shadow: none;
-    max-width: 100%;
-    width: 100%;
-    border-radius: 4px;
-    background-color: transparent;
-    border-color: rgb(118, 118, 118);
-    color: rgb(118, 118, 118);
     
 }
 
-body > footer .subscribe form input.button {
+body > footer .subscribe form input.input {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    padding: .5em;
+    width: 100%;
+}
 
-    background-color: rgb(255, 255, 255);
-    border-color: rgb(245, 245, 245);
-    border-width: 1px;
-    color: hsl(0, 0%, 21%);
+body > footer .subscribe form input.button {
+    justify-content: center;
+    padding: 1.1em;
+    
     cursor: pointer;
     font-family: "Roboto Condensed", sans-serif;
-    justify-content: center;
-    padding-bottom: calc(0.5em - 1px);
-    padding-left: 1em;
-    padding-right: 1em;
-    padding-top: calc(0.5em - 1px);
+    font-size: 1.125rem;
     text-align: center;
-    white-space: nowrap;
-
     text-transform: uppercase;
     font-weight: 600;
     line-height: 0;
-    background-color: rgb(209, 69, 0);
-    color: var(--button-color, #fff);
-    border: 0.125rem solid var(--button-border-color, transparent);
-    font-size: 1.125rem;
-    padding: 0.5rem 1rem;
-
-    font-size: 1rem;
-    padding: 0.5rem calc(1rem + 0.2rem);
-
-    margin-left: -1rem;
-    border: none;
+    white-space: nowrap;
     background-color: rgb(118, 118, 118);
-    color: rgb(255, 255, 255);
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    color: rgb(255, 255, 255);  
 }
 
 body > footer .donate {
@@ -622,9 +601,9 @@ body > footer .license svg {
     .primary-menu {
         display: none;
     }
-    .ancilliary-menu {
-        /* display: none; */
-    }
+    /* .ancilliary-menu {
+        display: none;
+    } */
 
     button.expand-menu {
         display: inline-block;

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -734,6 +734,10 @@ body > footer .license svg {
     body > footer {
         display: block;
     }
+
+    body > footer > nav, body > footer > div {
+        margin-bottom: 4em;
+    }
 }
 
 @media (max-width: 580px) {

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -438,6 +438,80 @@ body > footer .subscribe {
     grid-area: subscribe;
 }
 
+body > footer .subscribe form {
+    display: flex;
+}
+
+body > footer .subscribe form input {
+
+    -webkit-appearance: none;
+    align-items: center;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    box-shadow: none;
+    display: inline-flex;
+    font-size: 1rem;
+    height: 2.5em;
+    justify-content: flex-start;
+    line-height: 1.5;
+    padding-bottom: calc(0.5em - 1px);
+    padding-left: calc(0.75em - 1px);
+    padding-right: calc(0.75em - 1px);
+    padding-top: calc(0.5em - 1px);
+    position: relative;
+    vertical-align: top;
+
+    font-family: "Source Sans Pro", sans-serif;
+    font-weight: 600;
+    line-height: 1.3;
+    border-width: 0.125rem;
+    box-sizing: border-box;
+    height: 2.5em;
+    padding-left: 0.5rem;
+    box-shadow: none;
+    max-width: 100%;
+    width: 100%;
+    border-radius: 4px;
+    background-color: transparent;
+    border-color: rgb(118, 118, 118);
+    color: rgb(118, 118, 118);
+    
+}
+
+body > footer .subscribe form input.button {
+
+    background-color: rgb(255, 255, 255);
+    border-color: rgb(245, 245, 245);
+    border-width: 1px;
+    color: hsl(0, 0%, 21%);
+    cursor: pointer;
+    font-family: "Roboto Condensed", sans-serif;
+    justify-content: center;
+    padding-bottom: calc(0.5em - 1px);
+    padding-left: 1em;
+    padding-right: 1em;
+    padding-top: calc(0.5em - 1px);
+    text-align: center;
+    white-space: nowrap;
+
+    text-transform: uppercase;
+    font-weight: 600;
+    line-height: 0;
+    background-color: rgb(209, 69, 0);
+    color: var(--button-color, #fff);
+    border: 0.125rem solid var(--button-border-color, transparent);
+    font-size: 1.125rem;
+    padding: 0.5rem 1rem;
+
+    font-size: 1rem;
+    padding: 0.5rem calc(1rem + 0.2rem);
+
+    margin-left: -1rem;
+    border: none;
+    background-color: rgb(118, 118, 118);
+    color: rgb(255, 255, 255);
+}
+
 body > footer .donate {
     grid-area: donate;
 }

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -546,6 +546,10 @@ body > footer .subscribe form input.input {
     width: 100%;
 }
 
+body > footer .subscribe form input.input:focus {
+    color: white;
+}
+
 body > footer .subscribe form input.button {
     justify-content: center;
     padding: 1.1em;

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -2,6 +2,31 @@
 This is a prototype file for Vocabulary, 
 that may be later ported into Vocabulary 
 proper.
+
+Style rules are written with two sections 
+at current, separated by an empty line. 
+
+1. for layout, positioning, and related. 
+
+2. for visual configuration such 
+as color, font, background, etc.
+
+EX: 
+.selector {
+    layout style: rule here
+
+    visual style: rule here
+}
+
+EX:
+.article {
+    position: relative;
+    width: 100%;
+
+    color: blue;
+    text-decoration: none;
+}
+    
 */
 
 @import 'vendor/normalize.css';
@@ -423,7 +448,7 @@ body > footer p a {
     --underline-color: var(--vocabulary-brand-color-turquoise);
     --underline-background-color: black;
     color: var(--vocabulary-brand-color-turquoise);
-    text-decoration: none;
+    /* text-decoration: none; */
 
     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */
     background: -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(var( --underline-color), var( --underline-color)), -webkit-linear-gradient(currentColor, currentColor);

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -334,8 +334,9 @@ body > footer h2 {
     font-size: 1.25em;
 }
 
-body > footer a:link {
+body > footer a {
     color: var(--vocabulary-brand-color-turquoise);
+    text-decoration: none;
 }
 
 body > footer p {
@@ -343,11 +344,11 @@ body > footer p {
 }
 
 /* needs to be moved to be broader in general specificity scope */
-body > footer p a:link {
+body > footer p a {
     /* better hyperlink underline typesetting inspired by Tufte CSS */
     --underline-color: var(--vocabulary-brand-color-turquoise);
     --underline-background-color: black;
-
+    color: 
     text-decoration: none;
 
     /* adapted from Tufte.css -- Copyright (c) 2014 Dave Liepmann -- https://github.com/edwardtufte/tufte-css -- https://github.com/edwardtufte/tufte-css/blob/gh-pages/LICENSE */

--- a/src/css/vocabulary/vocabulary.css
+++ b/src/css/vocabulary/vocabulary.css
@@ -760,7 +760,16 @@ body > footer .license svg {
         display: block;
     }
 
-    body > footer > nav, body > footer > div {
+    body > footer > nav {
+        margin-top: 1em;
+        margin-bottom: 3em;
+    }
+
+    body > footer > nav ul li {
+        margin-bottom: 1em;
+    }
+
+    body > footer > div {
         margin-bottom: 4em;
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -270,7 +270,7 @@
     
 
     <div class="license">
-        <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
+        <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
             <use href="/svg/cc/icons/cc-icons.svg#cc-logo"></use>

--- a/src/index.html
+++ b/src/index.html
@@ -252,6 +252,14 @@
     
     <div class="subscribe">
     <h2>Subscribe to our Newsletter</h2>
+    <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate="">
+        <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required="">
+        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px" aria-hidden="true">
+          <input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value="">
+        </div>
+        <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
+      </form>
     </div>
     
     <div class="donate">

--- a/src/index.html
+++ b/src/index.html
@@ -224,11 +224,11 @@
     
     <nav class="footer-menu">
         <ul>
-            <li><a href="#">Contact</a></li>
-            <li><a href="#">Newsletter</a></li>
-            <li><a href="#">Privacy</a></li>
-            <li><a href="#">Policies</a></li>
-            <li><a href="#">Terms</a></li>
+            <li><a href="/about/contact">Contact</a></li>
+            <li><a href="https://mail.creativecommons.org/subscribe" target="_blank">Newsletter</a></li>
+            <li><a href="/privacy">Privacy</a></li>
+            <li><a href="/policies">Policies</a></li>
+            <li><a href="/terms">Terms</a></li>
         </ul>
     </nav>
     
@@ -236,16 +236,16 @@
     <!-- this area lacks a heading? -->
     <h2>Contact Us</h2>
     <p>Creative Commons </br> PO Box 1866, Mountain View, CA 94042</p>
-    <p><a href="#">info@creativecommons.org</a></p>
-    <p><a href="#">+1-415-429-6753</a></p>
+    <p><a href="mailto:info@creativecommons.org">info@creativecommons.org</a></p>
+    <p><a href="tel:+14154296753">+1-415-429-6753</a></p>
     
     <nav class="social-menu">
         <ul>
             <!-- <li><a class="icon-replace fa-instagram" href="#">Instagram</a></li> -->
-            <li><a class="icon-replace fa-twitter" href="#">Twitter</a></li>
-            <li><a class="icon-replace fa-mastodon" href="#">Mastodon</a></li>
-            <li><a class="icon-replace fa-facebook" href="#">Facebook</a></li>
-            <li><a class="icon-replace fa-linkedin" href="#">LinkedIn</a></li>
+            <li><a class="icon-replace fa-twitter" href="https://twitter.com/creativecommons" target="_blank">Twitter</a></li>
+            <li><a class="icon-replace fa-mastodon" href="https://mastodon.social/@creativecommons" target="_blank">Mastodon</a></li>
+            <li><a class="icon-replace fa-facebook" href="https://www.facebook.com/creativecommons" target="_blank">Facebook</a></li>
+            <li><a class="icon-replace fa-linkedin" href="https://www.linkedin.com/company/creative-commons/" target="_blank">LinkedIn</a></li>
         </ul>
     </nav>
     </div>
@@ -265,12 +265,12 @@
     <div class="donate">
         <h2>Support Our Work</h2>
         <p>Our work relies on you! Help us keep the Internet free and open.</p>
-        <a class="donate icon-attach cc-heart-filled">Donate Now</a>       
+        <a class="donate icon-attach cc-heart-filled" href="https://www.classy.org/give/313412/#!/donation/checkout?c_src=website&c_src2=top-of-page-banner" target="_blank">Donate Now</a>       
     </div>
     
 
     <div class="license">
-        <p>Except where otherwise <a href="#">noted</a>, content on this site is licensed under a <a href="#">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="#">Font Awesome</a>.</p>
+        <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
             <use href="/svg/cc/icons/cc-icons.svg#cc-logo"></use>


### PR DESCRIPTION
## Fixes
Fixes: 
* #13 
* #15 

## Description

Does all of the above, and also: 
* cleans up spacing issues with the various sections of the footer in smaller responsive stacked situations
* improves spacing for the footer nav area and its children in smaller responsive stacked situations
* adds commented documentation to the top of the `vocabulary.css` file to denote the split section convention for layout/visual styling
* removes an erroneous `text-decoration: none;`

## Tests
1. Run `docker compose up`
2. Navigate to site in browser
3. View changes at Desktop and mobile sizes (in between responsive fluidity fixes more broadly are coming in later PRs)

## Screenshots
<img width="1204" alt="Screen Shot 2023-05-04 at 3 34 56 PM" src="https://user-images.githubusercontent.com/109087089/236323109-72f02b46-b2de-48d3-b8d1-e85542f71c68.png">

<img width="495" alt="Screen Shot 2023-05-04 at 3 44 32 PM" src="https://user-images.githubusercontent.com/109087089/236325048-4d1b3f4d-5d97-4f0f-837a-d69c0a1d55d2.png">


<img width="570" alt="Screen Shot 2023-05-04 at 3 29 52 PM" src="https://user-images.githubusercontent.com/109087089/236322580-53b9fb74-4492-4673-9646-56c2d146d711.png">


<img width="345" alt="Screen Shot 2023-05-04 at 3 30 14 PM" src="https://user-images.githubusercontent.com/109087089/236322549-fc954b93-29ed-40ca-9785-01ffb1c17e84.png">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
