### PR TITLE
correct flex layout issue, correct styling to account for encasulated `<p>` tags around inner content of `blockquote` and `div.series`

### DIFF
--- a/src/context/blog-post.html
+++ b/src/context/blog-post.html
@@ -106,8 +106,10 @@
 </header>
 
     <div class="series">
+        <p>
         <span>part of the</span>
         <a href="#">Copyright and Artists</a> series, a unique take on how copyright isn't aligned with the interests of individual artists, but instead mega-corps.
+        </p>
         
     </div>
 

--- a/src/context/default-page.html
+++ b/src/context/default-page.html
@@ -157,7 +157,7 @@
 
 
 <blockquote>
-NASA is not only required by law (e.g. the U.S. Copyright Act of 1976) to give the public access to many of its materials, the Agency really wants people to use them.
+<p>NASA is not only required by law (e.g. the U.S. Copyright Act of 1976) to give the public access to many of its materials, the Agency really wants people to use them.</p>
 </blockquote>
 
 <figure>

--- a/src/vocabulary/css/vocabulary.css
+++ b/src/vocabulary/css/vocabulary.css
@@ -1266,6 +1266,7 @@ body > article.attention a {
 .authored-posts article header {
     display: flex;
     flex-wrap: wrap;
+    width: 100%;
 }
 
 .authored-posts article h2, .authored-posts article h3 {
@@ -1707,11 +1708,7 @@ main .series {
     padding: 2em;
     width: 100%;
 
-    font-family: 'Source Sans Pro';
-    font-size: 1.2em;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 150%; 
+    
     background: #FEEDE9;
     /* color: white; */
     /* color: var(--vocabulary-brand-color-dark-tomato); */
@@ -1722,6 +1719,16 @@ main .series {
 main .series a {
     color: var(--vocabulary-brand-color-dark-tomato);
     --underline-background-color: #FEEDE9;
+}
+
+main .series p {
+    margin :0;
+    
+    font-family: 'Source Sans Pro';
+    font-size: 1.2em;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 150%; 
 }
 
 
@@ -1776,14 +1783,10 @@ main blockquote {
     /* margin-left: -10%; */
     margin-bottom: 1.5em;
     padding: 0;
-
-    font-family: 'Source Sans Pro';
-    font-weight: bold;
-    font-size: 1.9em;
 }
 
 /* manually include quote icon to avoid extraneous html classes */
-main blockquote:before {
+main blockquote p:before {
     --icon-sprite: var(--fa-quote);
 
     display: block;
@@ -1802,7 +1805,18 @@ main blockquote:before {
 
 }
 
-main img {
+main blockquote p {
+    font-family: 'Source Sans Pro';
+    font-weight: bold;
+    font-size: 1.9em;
+    line-height: 105%;
+}
+
+/* main img[width] {
+    width: initial;
+} */
+
+main img:not([width]) {
     width: 100%;
 }
 
@@ -1817,7 +1831,7 @@ main figure {
 
 main figure .attribution {
 
-    display: inline-block;
+    display: block;
     margin-top: 1em;
 }
 


### PR DESCRIPTION
## Description
* corrects styles to account for `<p>` tags around inner content of both blockquote, and blog-post series wrapper elements.
* corrects a bug with `flex` whereby a short title, or short attribution caption, or short byline would trigger a flex layout changes that was not desired.

## Technical Details

* This does not attempt to refactor or cleanup the code formatting or styling yet, this mostly includes minor fixes/adjustments discovered when testing with `vocabulary-theme` that needed rectifying.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors. _(except for currently known and expected issues)_

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
